### PR TITLE
Added multiple solc versions

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -4,7 +4,10 @@ import '@nomiclabs/hardhat-ethers';
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: '0.6.10',
+    compilers: [
+      { version: "0.6.6"},
+      { version: "0.7.0"}
+    ],
     settings: {
       evmVersion: 'berlin',
       optimizer: { enabled: true, runs: 200 },


### PR DESCRIPTION
Fails to compile just using solc 0.6.10 due to SafeMath requiring solc = 0.6.6 & IDefiBridge + ERC20Mintable requiring a higher version